### PR TITLE
Distinguish "cart" type and "cart" object in tidybot

### DIFF
--- a/tidybot-opt11-strips/domain.pddl
+++ b/tidybot-opt11-strips/domain.pddl
@@ -5,7 +5,7 @@
 
 (define (domain TIDYBOT)
   (:requirements :strips :typing :equality)
-  (:types robot cart object xc yc xrel yrel)
+  (:types robot cart_t object xc yc xrel yrel)
   (:predicates
    ;; Constant preds
    (leftof                   ?x1 - xc ?x2 - xc)
@@ -35,11 +35,11 @@
    (gripper-obstacle         ?x - xc  ?y - yc)
  
    ;; Cart
-   (pushing       ?r - robot ?c - cart)
+   (pushing       ?r - robot ?c - cart_t)
    (not-pushing   ?r - robot)
-   (not-pushed    ?c - cart)
-   (cart-pos      ?c - cart ?x - xc ?y - yc)
-   (on-cart       ?o - object ?c - cart) 
+   (not-pushed    ?c - cart_t)
+   (cart-pos      ?c - cart_t ?x - xc ?y - yc)
+   (on-cart       ?o - object ?c - cart_t)
    )
 
   ;; Base movement actions
@@ -102,7 +102,7 @@
   ;; Base movement with cart
 
   (:action base-cart-left
-   :parameters (?r - robot ?c - cart ?x1 - xc ?x2 - xc ?y - yc ?cx1 - xc ?cx2 - xc ?cy - yc)
+   :parameters (?r - robot ?c - cart_t ?x1 - xc ?x2 - xc ?y - yc ?cx1 - xc ?cx2 - xc ?cy - yc)
    :precondition (and (pushing ?r ?c) (leftof ?x2 ?x1) (leftof ?cx2 ?cx1) 
                       (base-pos ?r ?x1 ?y) (cart-pos ?c ?cx1 ?cy)
                       (not (base-obstacle ?x2 ?y)) (not (base-obstacle ?cx2 ?cy)))
@@ -114,7 +114,7 @@
 
 
   (:action base-cart-right
-   :parameters (?r - robot ?c - cart ?x1 - xc ?x2 - xc ?y - yc ?cx1 - xc ?cx2 - xc ?cy - yc)
+   :parameters (?r - robot ?c - cart_t ?x1 - xc ?x2 - xc ?y - yc ?cx1 - xc ?cx2 - xc ?cy - yc)
    :precondition (and (pushing ?r ?c) (leftof ?x1 ?x2) (leftof ?cx1 ?cx2) 
                       (base-pos ?r ?x1 ?y) (cart-pos ?c ?cx1 ?cy)
                       (not (base-obstacle ?x2 ?y)) (not (base-obstacle ?cx2 ?cy)))
@@ -125,7 +125,7 @@
 
   
   (:action base-cart-up
-   :parameters (?r - robot ?c - cart ?x - xc ?y1 - yc ?y2 - yc ?cx - xc ?cy1 - yc ?cy2 - yc)
+   :parameters (?r - robot ?c - cart_t ?x - xc ?y1 - yc ?y2 - yc ?cx - xc ?cy1 - yc ?cy2 - yc)
    :precondition (and (pushing ?r ?c) (above ?y2 ?y1) (above ?cy2 ?cy1) 
                       (base-pos ?r ?x ?y1) (cart-pos ?c ?cx ?cy1)
                       (not (base-obstacle ?x ?y2)) (not (base-obstacle ?cx ?cy2)))
@@ -136,7 +136,7 @@
 
   
   (:action base-cart-down
-   :parameters (?r - robot ?c - cart ?x - xc ?y1 - yc ?y2 - yc ?cx - xc ?cy1 - yc ?cy2 - yc)
+   :parameters (?r - robot ?c - cart_t ?x - xc ?y1 - yc ?y2 - yc ?cx - xc ?cy1 - yc ?cy2 - yc)
    :precondition (and (pushing ?r ?c) (above ?y1 ?y2) (above ?cy1 ?cy2) 
                       (base-pos ?r ?x ?y1) (cart-pos ?c ?cx ?cy1)
                       (not (base-obstacle ?x ?y2)) (not (base-obstacle ?cx ?cy2)))
@@ -215,7 +215,7 @@
 
   ;; Cart grasping/ungrasping
   (:action grasp-cart-left
-   :parameters (?r - robot ?c - cart ?x - xc ?y - yc ?cx - xc)
+   :parameters (?r - robot ?c - cart_t ?x - xc ?y - yc ?cx - xc)
    :precondition (and (not (parked ?r)) (not-pushed ?c)
                       (base-pos ?r ?x ?y) (cart-pos ?c ?cx ?y)
                       (leftof ?cx ?x) (not-pushing ?r))
@@ -223,28 +223,28 @@
 
 
   (:action grasp-cart-right
-   :parameters (?r - robot ?c - cart ?x - xc ?y - yc ?cx - xc)
+   :parameters (?r - robot ?c - cart_t ?x - xc ?y - yc ?cx - xc)
    :precondition (and (not (parked ?r)) (not-pushed ?c)
                       (base-pos ?r ?x ?y) (cart-pos ?c ?cx ?y)
                       (leftof ?x ?cx) (not-pushing ?r))
    :effect       (and (pushing ?r ?c) (not (not-pushing ?r)) (not (not-pushed ?c))))
 
   (:action grasp-cart-above
-   :parameters (?r - robot ?c - cart ?x - xc ?y - yc ?cy - yc)
+   :parameters (?r - robot ?c - cart_t ?x - xc ?y - yc ?cy - yc)
    :precondition (and (not (parked ?r)) (not-pushed ?c)
                       (base-pos ?r ?x ?y) (cart-pos ?c ?x ?cy)
                       (above ?cy ?y) (not-pushing ?r))
    :effect       (and (pushing ?r ?c) (not (not-pushing ?r)) (not (not-pushed ?c))))
   
   (:action grasp-cart-below
-   :parameters (?r - robot ?c - cart ?x - xc ?y - yc ?cy - yc)
+   :parameters (?r - robot ?c - cart_t ?x - xc ?y - yc ?cy - yc)
    :precondition (and (not (parked ?r)) (not-pushed ?c)
                       (base-pos ?r ?x ?y) (cart-pos ?c ?x ?cy)
                       (above ?y ?cy) (not-pushing ?r))
    :effect       (and (pushing ?r ?c) (not (not-pushing ?r)) (not (not-pushed ?c))))
 
   (:action ungrasp-cart
-   :parameters (?r - robot ?c - cart )
+   :parameters (?r - robot ?c - cart_t )
    :precondition (and (pushing ?r ?c))
    :effect (and (not (pushing ?r ?c)) (not-pushing ?r) (not-pushed ?c)))
   
@@ -325,7 +325,7 @@
 
   (:action get-from-cart
    :parameters (?r - robot ?x - xc ?y - yc ?gxrel - xrel 
-                ?gyrel - yrel ?o - object ?c - cart
+                ?gyrel - yrel ?o - object ?c - cart_t
                 ?cx - xc ?cy - yc)
    :precondition (and (parked ?r) (base-pos ?r ?x ?y)
                       (gripper-rel ?r ?gxrel ?gyrel) (sum-x ?x ?gxrel ?cx)
@@ -420,7 +420,7 @@
 
   (:action put-on-cart
    :parameters (?r - robot ?x - xc ?y - yc ?gxrel - xrel 
-                ?gyrel - yrel ?o - object ?c - cart ?cx - xc ?cy - yc)
+                ?gyrel - yrel ?o - object ?c - cart_t ?cx - xc ?cy - yc)
 
    :precondition (and (parked ?r) (base-pos ?r ?x ?y) (gripper-rel ?r ?gxrel ?gyrel)
                       (sum-x ?x ?gxrel ?cx) (sum-y ?y ?gyrel ?cy) (cart-pos ?c ?cx ?cy)

--- a/tidybot-opt11-strips/p01.pddl
+++ b/tidybot-opt11-strips/p01.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt11-strips/p02.pddl
+++ b/tidybot-opt11-strips/p02.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt11-strips/p03.pddl
+++ b/tidybot-opt11-strips/p03.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt11-strips/p04.pddl
+++ b/tidybot-opt11-strips/p04.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt11-strips/p05.pddl
+++ b/tidybot-opt11-strips/p05.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt11-strips/p06.pddl
+++ b/tidybot-opt11-strips/p06.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt11-strips/p07.pddl
+++ b/tidybot-opt11-strips/p07.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt11-strips/p08.pddl
+++ b/tidybot-opt11-strips/p08.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt11-strips/p09.pddl
+++ b/tidybot-opt11-strips/p09.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt11-strips/p10.pddl
+++ b/tidybot-opt11-strips/p10.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt11-strips/p11.pddl
+++ b/tidybot-opt11-strips/p11.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt11-strips/p12.pddl
+++ b/tidybot-opt11-strips/p12.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt11-strips/p13.pddl
+++ b/tidybot-opt11-strips/p13.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt11-strips/p14.pddl
+++ b/tidybot-opt11-strips/p14.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt11-strips/p15.pddl
+++ b/tidybot-opt11-strips/p15.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt11-strips/p16.pddl
+++ b/tidybot-opt11-strips/p16.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt11-strips/p17.pddl
+++ b/tidybot-opt11-strips/p17.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt11-strips/p18.pddl
+++ b/tidybot-opt11-strips/p18.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt11-strips/p19.pddl
+++ b/tidybot-opt11-strips/p19.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt11-strips/p20.pddl
+++ b/tidybot-opt11-strips/p20.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt14-strips/domain.pddl
+++ b/tidybot-opt14-strips/domain.pddl
@@ -5,7 +5,7 @@
 
 (define (domain TIDYBOT)
   (:requirements :strips :typing :equality)
-  (:types robot cart object xc yc xrel yrel)
+  (:types robot cart_t object xc yc xrel yrel)
   (:predicates
    ;; Constant preds
    (leftof                   ?x1 - xc ?x2 - xc)
@@ -33,13 +33,13 @@
    (gripper-empty ?r - robot)
    (gripper-rel   ?r - robot ?x - xrel ?y - yrel)
    (gripper-obstacle         ?x - xc  ?y - yc)
- 
+
    ;; Cart
-   (pushing       ?r - robot ?c - cart)
+   (pushing       ?r - robot ?c - cart_t)
    (not-pushing   ?r - robot)
-   (not-pushed    ?c - cart)
-   (cart-pos      ?c - cart ?x - xc ?y - yc)
-   (on-cart       ?o - object ?c - cart) 
+   (not-pushed    ?c - cart_t)
+   (cart-pos      ?c - cart_t ?x - xc ?y - yc)
+   (on-cart       ?o - object ?c - cart_t)
    )
 
   ;; Base movement actions
@@ -54,7 +54,7 @@
    :precondition (and (not (parked ?r)) (not-pushing ?r))
    :effect       (parked ?r)
    )
-  
+
   (:action base-left
    :parameters (?r - robot ?cx - xc ?dx - xc ?y - yc)
    :precondition (and (not (parked ?r))
@@ -102,8 +102,8 @@
   ;; Base movement with cart
 
   (:action base-cart-left
-   :parameters (?r - robot ?c - cart ?x1 - xc ?x2 - xc ?y - yc ?cx1 - xc ?cx2 - xc ?cy - yc)
-   :precondition (and (pushing ?r ?c) (leftof ?x2 ?x1) (leftof ?cx2 ?cx1) 
+   :parameters (?r - robot ?c - cart_t ?x1 - xc ?x2 - xc ?y - yc ?cx1 - xc ?cx2 - xc ?cy - yc)
+   :precondition (and (pushing ?r ?c) (leftof ?x2 ?x1) (leftof ?cx2 ?cx1)
                       (base-pos ?r ?x1 ?y) (cart-pos ?c ?cx1 ?cy)
                       (not (base-obstacle ?x2 ?y)) (not (base-obstacle ?cx2 ?cy)))
    :effect       (and (not (base-pos ?r ?x1 ?y)) (base-pos ?r ?x2 ?y)
@@ -114,8 +114,8 @@
 
 
   (:action base-cart-right
-   :parameters (?r - robot ?c - cart ?x1 - xc ?x2 - xc ?y - yc ?cx1 - xc ?cx2 - xc ?cy - yc)
-   :precondition (and (pushing ?r ?c) (leftof ?x1 ?x2) (leftof ?cx1 ?cx2) 
+   :parameters (?r - robot ?c - cart_t ?x1 - xc ?x2 - xc ?y - yc ?cx1 - xc ?cx2 - xc ?cy - yc)
+   :precondition (and (pushing ?r ?c) (leftof ?x1 ?x2) (leftof ?cx1 ?cx2)
                       (base-pos ?r ?x1 ?y) (cart-pos ?c ?cx1 ?cy)
                       (not (base-obstacle ?x2 ?y)) (not (base-obstacle ?cx2 ?cy)))
    :effect       (and (not (base-pos ?r ?x1 ?y)) (base-pos ?r ?x2 ?y)
@@ -123,10 +123,10 @@
                       (not (base-obstacle ?x1 ?y)) (base-obstacle ?x2 ?y)
                       (not (base-obstacle ?cx1 ?cy)) (base-obstacle ?cx2 ?cy)))
 
-  
+
   (:action base-cart-up
-   :parameters (?r - robot ?c - cart ?x - xc ?y1 - yc ?y2 - yc ?cx - xc ?cy1 - yc ?cy2 - yc)
-   :precondition (and (pushing ?r ?c) (above ?y2 ?y1) (above ?cy2 ?cy1) 
+   :parameters (?r - robot ?c - cart_t ?x - xc ?y1 - yc ?y2 - yc ?cx - xc ?cy1 - yc ?cy2 - yc)
+   :precondition (and (pushing ?r ?c) (above ?y2 ?y1) (above ?cy2 ?cy1)
                       (base-pos ?r ?x ?y1) (cart-pos ?c ?cx ?cy1)
                       (not (base-obstacle ?x ?y2)) (not (base-obstacle ?cx ?cy2)))
    :effect       (and (not (base-pos ?r ?x ?y1)) (base-pos ?r ?x ?y2)
@@ -134,10 +134,10 @@
                       (not (base-obstacle ?x ?y1)) (base-obstacle ?x ?y2)
                       (not (base-obstacle ?cx ?cy2)) (base-obstacle ?cx ?cy2)))
 
-  
+
   (:action base-cart-down
-   :parameters (?r - robot ?c - cart ?x - xc ?y1 - yc ?y2 - yc ?cx - xc ?cy1 - yc ?cy2 - yc)
-   :precondition (and (pushing ?r ?c) (above ?y1 ?y2) (above ?cy1 ?cy2) 
+   :parameters (?r - robot ?c - cart_t ?x - xc ?y1 - yc ?y2 - yc ?cx - xc ?cy1 - yc ?cy2 - yc)
+   :precondition (and (pushing ?r ?c) (above ?y1 ?y2) (above ?cy1 ?cy2)
                       (base-pos ?r ?x ?y1) (cart-pos ?c ?cx ?cy1)
                       (not (base-obstacle ?x ?y2)) (not (base-obstacle ?cx ?cy2)))
    :effect       (and (not (base-pos ?r ?x ?y1)) (base-pos ?r ?x ?y2)
@@ -184,7 +184,7 @@
   (:action gripper-up
    :parameters (?r - robot ?basex - xc ?basey - yc
                 ?gxrel - xrel ?gxabs - xc
-                ?cgyrel - yrel ?dgyrel - yrel ?cgyabs - yc ?dgyabs - yc)   
+                ?cgyrel - yrel ?dgyrel - yrel ?cgyabs - yc ?dgyabs - yc)
    :precondition (and (parked ?r)
                       (base-pos ?r ?basex ?basey)
                       (gripper-rel ?r ?gxrel ?cgyrel)
@@ -200,7 +200,7 @@
   (:action gripper-down
    :parameters (?r - robot ?basex - xc ?basey - yc
                 ?gxrel - xrel ?gxabs - xc
-                ?cgyrel - yrel ?dgyrel - yrel ?cgyabs - yc ?dgyabs - yc)   
+                ?cgyrel - yrel ?dgyrel - yrel ?cgyabs - yc ?dgyabs - yc)
    :precondition (and (parked ?r)
                       (base-pos ?r ?basex ?basey)
                       (gripper-rel ?r ?gxrel ?cgyrel)
@@ -215,7 +215,7 @@
 
   ;; Cart grasping/ungrasping
   (:action grasp-cart-left
-   :parameters (?r - robot ?c - cart ?x - xc ?y - yc ?cx - xc)
+   :parameters (?r - robot ?c - cart_t ?x - xc ?y - yc ?cx - xc)
    :precondition (and (not (parked ?r)) (not-pushed ?c)
                       (base-pos ?r ?x ?y) (cart-pos ?c ?cx ?y)
                       (leftof ?cx ?x) (not-pushing ?r))
@@ -223,38 +223,38 @@
 
 
   (:action grasp-cart-right
-   :parameters (?r - robot ?c - cart ?x - xc ?y - yc ?cx - xc)
+   :parameters (?r - robot ?c - cart_t ?x - xc ?y - yc ?cx - xc)
    :precondition (and (not (parked ?r)) (not-pushed ?c)
                       (base-pos ?r ?x ?y) (cart-pos ?c ?cx ?y)
                       (leftof ?x ?cx) (not-pushing ?r))
    :effect       (and (pushing ?r ?c) (not (not-pushing ?r)) (not (not-pushed ?c))))
 
   (:action grasp-cart-above
-   :parameters (?r - robot ?c - cart ?x - xc ?y - yc ?cy - yc)
+   :parameters (?r - robot ?c - cart_t ?x - xc ?y - yc ?cy - yc)
    :precondition (and (not (parked ?r)) (not-pushed ?c)
                       (base-pos ?r ?x ?y) (cart-pos ?c ?x ?cy)
                       (above ?cy ?y) (not-pushing ?r))
    :effect       (and (pushing ?r ?c) (not (not-pushing ?r)) (not (not-pushed ?c))))
-  
+
   (:action grasp-cart-below
-   :parameters (?r - robot ?c - cart ?x - xc ?y - yc ?cy - yc)
+   :parameters (?r - robot ?c - cart_t ?x - xc ?y - yc ?cy - yc)
    :precondition (and (not (parked ?r)) (not-pushed ?c)
                       (base-pos ?r ?x ?y) (cart-pos ?c ?x ?cy)
                       (above ?y ?cy) (not-pushing ?r))
    :effect       (and (pushing ?r ?c) (not (not-pushing ?r)) (not (not-pushed ?c))))
 
   (:action ungrasp-cart
-   :parameters (?r - robot ?c - cart )
+   :parameters (?r - robot ?c - cart_t )
    :precondition (and (pushing ?r ?c))
    :effect (and (not (pushing ?r ?c)) (not-pushing ?r) (not-pushed ?c)))
-  
+
   ;; Object manipulation actions
 
 
   (:action get-left
    :parameters (?r - robot ?basex - xc ?basey - yc
                 ?gxrel - xrel ?gxabs - xc ?gyrel - yrel ?gyabs - yc
-                ?o - object ?ox - xc)   
+                ?o - object ?ox - xc)
    :precondition (and (parked ?r)
                       (base-pos ?r ?basex ?basey)
                       (gripper-rel ?r ?gxrel ?gyrel)
@@ -272,7 +272,7 @@
   (:action get-right
    :parameters (?r - robot ?basex - xc ?basey - yc
                 ?gxrel - xrel ?gxabs - xc ?gyrel - yrel ?gyabs - yc
-                ?o - object ?ox - xc)   
+                ?o - object ?ox - xc)
    :precondition (and (parked ?r)
                       (base-pos ?r ?basex ?basey)
                       (gripper-rel ?r ?gxrel ?gyrel)
@@ -290,7 +290,7 @@
   (:action get-up
    :parameters (?r - robot ?basex - xc ?basey - yc
                 ?gxrel - xrel ?gxabs - xc ?gyrel - yrel ?gyabs - yc
-                ?o - object ?oy - yc)   
+                ?o - object ?oy - yc)
    :precondition (and (parked ?r)
                       (base-pos ?r ?basex ?basey)
                       (gripper-rel ?r ?gxrel ?gyrel)
@@ -304,11 +304,11 @@
                       (not (gripper-empty ?r))
                       (holding ?r ?o))
    )
-  
+
   (:action get-down
    :parameters (?r - robot ?basex - xc ?basey - yc
                 ?gxrel - xrel ?gxabs - xc ?gyrel - yrel ?gyabs - yc
-                ?o - object ?oy - yc)   
+                ?o - object ?oy - yc)
    :precondition (and (parked ?r)
                       (base-pos ?r ?basex ?basey)
                       (gripper-rel ?r ?gxrel ?gyrel)
@@ -324,8 +324,8 @@
    )
 
   (:action get-from-cart
-   :parameters (?r - robot ?x - xc ?y - yc ?gxrel - xrel 
-                ?gyrel - yrel ?o - object ?c - cart
+   :parameters (?r - robot ?x - xc ?y - yc ?gxrel - xrel
+                ?gyrel - yrel ?o - object ?c - cart_t
                 ?cx - xc ?cy - yc)
    :precondition (and (parked ?r) (base-pos ?r ?x ?y)
                       (gripper-rel ?r ?gxrel ?gyrel) (sum-x ?x ?gxrel ?cx)
@@ -333,11 +333,11 @@
                       (on-cart ?o ?c))
    :effect       (and (holding ?r ?o) (not (gripper-empty ?r)) (not (on-cart ?o ?c))))
 
-  
+
   (:action put-left
    :parameters (?r - robot ?basex - xc ?basey - yc
                 ?gxrel - xrel ?gxabs - xc ?gyrel - yrel ?gyabs - yc
-                ?o - object ?ox - xc)   
+                ?o - object ?ox - xc)
    :precondition (and (parked ?r)
                       (base-pos ?r ?basex ?basey)
                       (gripper-rel ?r ?gxrel ?gyrel)
@@ -352,13 +352,13 @@
                       (object-pos ?o ?ox ?gyabs)
                       (gripper-obstacle ?ox ?gyabs)
                       (gripper-empty ?r)
-                      )   
+                      )
    )
 
   (:action put-right
    :parameters (?r - robot ?basex - xc ?basey - yc
                 ?gxrel - xrel ?gxabs - xc ?gyrel - yrel ?gyabs - yc
-                ?o - object ?ox - xc)   
+                ?o - object ?ox - xc)
    :precondition (and (parked ?r)
                       (base-pos ?r ?basex ?basey)
                       (gripper-rel ?r ?gxrel ?gyrel)
@@ -373,13 +373,13 @@
                       (object-pos ?o ?ox ?gyabs)
                       (gripper-obstacle ?ox ?gyabs)
                       (gripper-empty ?r)
-                      )   
+                      )
    )
 
   (:action put-up
    :parameters (?r - robot ?basex - xc ?basey - yc
                 ?gxrel - xrel ?gxabs - xc ?gyrel - yrel ?gyabs - yc
-                ?o - object ?oy - yc)   
+                ?o - object ?oy - yc)
    :precondition (and (parked ?r)
                       (base-pos ?r ?basex ?basey)
                       (gripper-rel ?r ?gxrel ?gyrel)
@@ -394,13 +394,13 @@
                       (object-pos ?o ?gxabs ?oy)
                       (gripper-obstacle ?gxabs ?oy)
                       (gripper-empty ?r)
-                      )   
+                      )
    )
 
   (:action put-down
    :parameters (?r - robot ?basex - xc ?basey - yc
                 ?gxrel - xrel ?gxabs - xc ?gyrel - yrel ?gyabs - yc
-                ?o - object ?oy - yc)   
+                ?o - object ?oy - yc)
    :precondition (and (parked ?r)
                       (base-pos ?r ?basex ?basey)
                       (gripper-rel ?r ?gxrel ?gyrel)
@@ -415,12 +415,12 @@
                       (object-pos ?o ?gxabs ?oy)
                       (gripper-obstacle ?gxabs ?oy)
                       (gripper-empty ?r)
-                      )   
+                      )
    )
 
   (:action put-on-cart
-   :parameters (?r - robot ?x - xc ?y - yc ?gxrel - xrel 
-                ?gyrel - yrel ?o - object ?c - cart ?cx - xc ?cy - yc)
+   :parameters (?r - robot ?x - xc ?y - yc ?gxrel - xrel
+                ?gyrel - yrel ?o - object ?c - cart_t ?cx - xc ?cy - yc)
 
    :precondition (and (parked ?r) (base-pos ?r ?x ?y) (gripper-rel ?r ?gxrel ?gyrel)
                       (sum-x ?x ?gxrel ?cx) (sum-y ?y ?gyrel ?cy) (cart-pos ?c ?cx ?cy)

--- a/tidybot-opt14-strips/p01.pddl
+++ b/tidybot-opt14-strips/p01.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt14-strips/p02.pddl
+++ b/tidybot-opt14-strips/p02.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt14-strips/p03.pddl
+++ b/tidybot-opt14-strips/p03.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt14-strips/p04.pddl
+++ b/tidybot-opt14-strips/p04.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt14-strips/p05.pddl
+++ b/tidybot-opt14-strips/p05.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt14-strips/p06.pddl
+++ b/tidybot-opt14-strips/p06.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt14-strips/p07.pddl
+++ b/tidybot-opt14-strips/p07.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt14-strips/p08.pddl
+++ b/tidybot-opt14-strips/p08.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt14-strips/p09.pddl
+++ b/tidybot-opt14-strips/p09.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt14-strips/p10.pddl
+++ b/tidybot-opt14-strips/p10.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt14-strips/p11.pddl
+++ b/tidybot-opt14-strips/p11.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt14-strips/p12.pddl
+++ b/tidybot-opt14-strips/p12.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt14-strips/p13.pddl
+++ b/tidybot-opt14-strips/p13.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt14-strips/p14.pddl
+++ b/tidybot-opt14-strips/p14.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt14-strips/p15.pddl
+++ b/tidybot-opt14-strips/p15.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt14-strips/p16.pddl
+++ b/tidybot-opt14-strips/p16.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt14-strips/p17.pddl
+++ b/tidybot-opt14-strips/p17.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt14-strips/p18.pddl
+++ b/tidybot-opt14-strips/p18.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt14-strips/p19.pddl
+++ b/tidybot-opt14-strips/p19.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-opt14-strips/p20.pddl
+++ b/tidybot-opt14-strips/p20.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-sat11-strips/domain.pddl
+++ b/tidybot-sat11-strips/domain.pddl
@@ -5,7 +5,7 @@
 
 (define (domain TIDYBOT)
   (:requirements :strips :typing :equality)
-  (:types robot cart object xc yc xrel yrel)
+  (:types robot cart_t object xc yc xrel yrel)
   (:predicates
    ;; Constant preds
    (leftof                   ?x1 - xc ?x2 - xc)
@@ -33,13 +33,13 @@
    (gripper-empty ?r - robot)
    (gripper-rel   ?r - robot ?x - xrel ?y - yrel)
    (gripper-obstacle         ?x - xc  ?y - yc)
- 
+
    ;; Cart
-   (pushing       ?r - robot ?c - cart)
+   (pushing       ?r - robot ?c - cart_t)
    (not-pushing   ?r - robot)
-   (not-pushed    ?c - cart)
-   (cart-pos      ?c - cart ?x - xc ?y - yc)
-   (on-cart       ?o - object ?c - cart) 
+   (not-pushed    ?c - cart_t)
+   (cart-pos      ?c - cart_t ?x - xc ?y - yc)
+   (on-cart       ?o - object ?c - cart_t)
    )
 
   ;; Base movement actions
@@ -54,7 +54,7 @@
    :precondition (and (not (parked ?r)) (not-pushing ?r))
    :effect       (parked ?r)
    )
-  
+
   (:action base-left
    :parameters (?r - robot ?cx - xc ?dx - xc ?y - yc)
    :precondition (and (not (parked ?r))
@@ -102,8 +102,8 @@
   ;; Base movement with cart
 
   (:action base-cart-left
-   :parameters (?r - robot ?c - cart ?x1 - xc ?x2 - xc ?y - yc ?cx1 - xc ?cx2 - xc ?cy - yc)
-   :precondition (and (pushing ?r ?c) (leftof ?x2 ?x1) (leftof ?cx2 ?cx1) 
+   :parameters (?r - robot ?c - cart_t ?x1 - xc ?x2 - xc ?y - yc ?cx1 - xc ?cx2 - xc ?cy - yc)
+   :precondition (and (pushing ?r ?c) (leftof ?x2 ?x1) (leftof ?cx2 ?cx1)
                       (base-pos ?r ?x1 ?y) (cart-pos ?c ?cx1 ?cy)
                       (not (base-obstacle ?x2 ?y)) (not (base-obstacle ?cx2 ?cy)))
    :effect       (and (not (base-pos ?r ?x1 ?y)) (base-pos ?r ?x2 ?y)
@@ -114,8 +114,8 @@
 
 
   (:action base-cart-right
-   :parameters (?r - robot ?c - cart ?x1 - xc ?x2 - xc ?y - yc ?cx1 - xc ?cx2 - xc ?cy - yc)
-   :precondition (and (pushing ?r ?c) (leftof ?x1 ?x2) (leftof ?cx1 ?cx2) 
+   :parameters (?r - robot ?c - cart_t ?x1 - xc ?x2 - xc ?y - yc ?cx1 - xc ?cx2 - xc ?cy - yc)
+   :precondition (and (pushing ?r ?c) (leftof ?x1 ?x2) (leftof ?cx1 ?cx2)
                       (base-pos ?r ?x1 ?y) (cart-pos ?c ?cx1 ?cy)
                       (not (base-obstacle ?x2 ?y)) (not (base-obstacle ?cx2 ?cy)))
    :effect       (and (not (base-pos ?r ?x1 ?y)) (base-pos ?r ?x2 ?y)
@@ -123,10 +123,10 @@
                       (not (base-obstacle ?x1 ?y)) (base-obstacle ?x2 ?y)
                       (not (base-obstacle ?cx1 ?cy)) (base-obstacle ?cx2 ?cy)))
 
-  
+
   (:action base-cart-up
-   :parameters (?r - robot ?c - cart ?x - xc ?y1 - yc ?y2 - yc ?cx - xc ?cy1 - yc ?cy2 - yc)
-   :precondition (and (pushing ?r ?c) (above ?y2 ?y1) (above ?cy2 ?cy1) 
+   :parameters (?r - robot ?c - cart_t ?x - xc ?y1 - yc ?y2 - yc ?cx - xc ?cy1 - yc ?cy2 - yc)
+   :precondition (and (pushing ?r ?c) (above ?y2 ?y1) (above ?cy2 ?cy1)
                       (base-pos ?r ?x ?y1) (cart-pos ?c ?cx ?cy1)
                       (not (base-obstacle ?x ?y2)) (not (base-obstacle ?cx ?cy2)))
    :effect       (and (not (base-pos ?r ?x ?y1)) (base-pos ?r ?x ?y2)
@@ -134,10 +134,10 @@
                       (not (base-obstacle ?x ?y1)) (base-obstacle ?x ?y2)
                       (not (base-obstacle ?cx ?cy2)) (base-obstacle ?cx ?cy2)))
 
-  
+
   (:action base-cart-down
-   :parameters (?r - robot ?c - cart ?x - xc ?y1 - yc ?y2 - yc ?cx - xc ?cy1 - yc ?cy2 - yc)
-   :precondition (and (pushing ?r ?c) (above ?y1 ?y2) (above ?cy1 ?cy2) 
+   :parameters (?r - robot ?c - cart_t ?x - xc ?y1 - yc ?y2 - yc ?cx - xc ?cy1 - yc ?cy2 - yc)
+   :precondition (and (pushing ?r ?c) (above ?y1 ?y2) (above ?cy1 ?cy2)
                       (base-pos ?r ?x ?y1) (cart-pos ?c ?cx ?cy1)
                       (not (base-obstacle ?x ?y2)) (not (base-obstacle ?cx ?cy2)))
    :effect       (and (not (base-pos ?r ?x ?y1)) (base-pos ?r ?x ?y2)
@@ -184,7 +184,7 @@
   (:action gripper-up
    :parameters (?r - robot ?basex - xc ?basey - yc
                 ?gxrel - xrel ?gxabs - xc
-                ?cgyrel - yrel ?dgyrel - yrel ?cgyabs - yc ?dgyabs - yc)   
+                ?cgyrel - yrel ?dgyrel - yrel ?cgyabs - yc ?dgyabs - yc)
    :precondition (and (parked ?r)
                       (base-pos ?r ?basex ?basey)
                       (gripper-rel ?r ?gxrel ?cgyrel)
@@ -200,7 +200,7 @@
   (:action gripper-down
    :parameters (?r - robot ?basex - xc ?basey - yc
                 ?gxrel - xrel ?gxabs - xc
-                ?cgyrel - yrel ?dgyrel - yrel ?cgyabs - yc ?dgyabs - yc)   
+                ?cgyrel - yrel ?dgyrel - yrel ?cgyabs - yc ?dgyabs - yc)
    :precondition (and (parked ?r)
                       (base-pos ?r ?basex ?basey)
                       (gripper-rel ?r ?gxrel ?cgyrel)
@@ -215,7 +215,7 @@
 
   ;; Cart grasping/ungrasping
   (:action grasp-cart-left
-   :parameters (?r - robot ?c - cart ?x - xc ?y - yc ?cx - xc)
+   :parameters (?r - robot ?c - cart_t ?x - xc ?y - yc ?cx - xc)
    :precondition (and (not (parked ?r)) (not-pushed ?c)
                       (base-pos ?r ?x ?y) (cart-pos ?c ?cx ?y)
                       (leftof ?cx ?x) (not-pushing ?r))
@@ -223,38 +223,38 @@
 
 
   (:action grasp-cart-right
-   :parameters (?r - robot ?c - cart ?x - xc ?y - yc ?cx - xc)
+   :parameters (?r - robot ?c - cart_t ?x - xc ?y - yc ?cx - xc)
    :precondition (and (not (parked ?r)) (not-pushed ?c)
                       (base-pos ?r ?x ?y) (cart-pos ?c ?cx ?y)
                       (leftof ?x ?cx) (not-pushing ?r))
    :effect       (and (pushing ?r ?c) (not (not-pushing ?r)) (not (not-pushed ?c))))
 
   (:action grasp-cart-above
-   :parameters (?r - robot ?c - cart ?x - xc ?y - yc ?cy - yc)
+   :parameters (?r - robot ?c - cart_t ?x - xc ?y - yc ?cy - yc)
    :precondition (and (not (parked ?r)) (not-pushed ?c)
                       (base-pos ?r ?x ?y) (cart-pos ?c ?x ?cy)
                       (above ?cy ?y) (not-pushing ?r))
    :effect       (and (pushing ?r ?c) (not (not-pushing ?r)) (not (not-pushed ?c))))
-  
+
   (:action grasp-cart-below
-   :parameters (?r - robot ?c - cart ?x - xc ?y - yc ?cy - yc)
+   :parameters (?r - robot ?c - cart_t ?x - xc ?y - yc ?cy - yc)
    :precondition (and (not (parked ?r)) (not-pushed ?c)
                       (base-pos ?r ?x ?y) (cart-pos ?c ?x ?cy)
                       (above ?y ?cy) (not-pushing ?r))
    :effect       (and (pushing ?r ?c) (not (not-pushing ?r)) (not (not-pushed ?c))))
 
   (:action ungrasp-cart
-   :parameters (?r - robot ?c - cart )
+   :parameters (?r - robot ?c - cart_t )
    :precondition (and (pushing ?r ?c))
    :effect (and (not (pushing ?r ?c)) (not-pushing ?r) (not-pushed ?c)))
-  
+
   ;; Object manipulation actions
 
 
   (:action get-left
    :parameters (?r - robot ?basex - xc ?basey - yc
                 ?gxrel - xrel ?gxabs - xc ?gyrel - yrel ?gyabs - yc
-                ?o - object ?ox - xc)   
+                ?o - object ?ox - xc)
    :precondition (and (parked ?r)
                       (base-pos ?r ?basex ?basey)
                       (gripper-rel ?r ?gxrel ?gyrel)
@@ -272,7 +272,7 @@
   (:action get-right
    :parameters (?r - robot ?basex - xc ?basey - yc
                 ?gxrel - xrel ?gxabs - xc ?gyrel - yrel ?gyabs - yc
-                ?o - object ?ox - xc)   
+                ?o - object ?ox - xc)
    :precondition (and (parked ?r)
                       (base-pos ?r ?basex ?basey)
                       (gripper-rel ?r ?gxrel ?gyrel)
@@ -290,7 +290,7 @@
   (:action get-up
    :parameters (?r - robot ?basex - xc ?basey - yc
                 ?gxrel - xrel ?gxabs - xc ?gyrel - yrel ?gyabs - yc
-                ?o - object ?oy - yc)   
+                ?o - object ?oy - yc)
    :precondition (and (parked ?r)
                       (base-pos ?r ?basex ?basey)
                       (gripper-rel ?r ?gxrel ?gyrel)
@@ -304,11 +304,11 @@
                       (not (gripper-empty ?r))
                       (holding ?r ?o))
    )
-  
+
   (:action get-down
    :parameters (?r - robot ?basex - xc ?basey - yc
                 ?gxrel - xrel ?gxabs - xc ?gyrel - yrel ?gyabs - yc
-                ?o - object ?oy - yc)   
+                ?o - object ?oy - yc)
    :precondition (and (parked ?r)
                       (base-pos ?r ?basex ?basey)
                       (gripper-rel ?r ?gxrel ?gyrel)
@@ -324,8 +324,8 @@
    )
 
   (:action get-from-cart
-   :parameters (?r - robot ?x - xc ?y - yc ?gxrel - xrel 
-                ?gyrel - yrel ?o - object ?c - cart
+   :parameters (?r - robot ?x - xc ?y - yc ?gxrel - xrel
+                ?gyrel - yrel ?o - object ?c - cart_t
                 ?cx - xc ?cy - yc)
    :precondition (and (parked ?r) (base-pos ?r ?x ?y)
                       (gripper-rel ?r ?gxrel ?gyrel) (sum-x ?x ?gxrel ?cx)
@@ -333,11 +333,11 @@
                       (on-cart ?o ?c))
    :effect       (and (holding ?r ?o) (not (gripper-empty ?r)) (not (on-cart ?o ?c))))
 
-  
+
   (:action put-left
    :parameters (?r - robot ?basex - xc ?basey - yc
                 ?gxrel - xrel ?gxabs - xc ?gyrel - yrel ?gyabs - yc
-                ?o - object ?ox - xc)   
+                ?o - object ?ox - xc)
    :precondition (and (parked ?r)
                       (base-pos ?r ?basex ?basey)
                       (gripper-rel ?r ?gxrel ?gyrel)
@@ -352,13 +352,13 @@
                       (object-pos ?o ?ox ?gyabs)
                       (gripper-obstacle ?ox ?gyabs)
                       (gripper-empty ?r)
-                      )   
+                      )
    )
 
   (:action put-right
    :parameters (?r - robot ?basex - xc ?basey - yc
                 ?gxrel - xrel ?gxabs - xc ?gyrel - yrel ?gyabs - yc
-                ?o - object ?ox - xc)   
+                ?o - object ?ox - xc)
    :precondition (and (parked ?r)
                       (base-pos ?r ?basex ?basey)
                       (gripper-rel ?r ?gxrel ?gyrel)
@@ -373,13 +373,13 @@
                       (object-pos ?o ?ox ?gyabs)
                       (gripper-obstacle ?ox ?gyabs)
                       (gripper-empty ?r)
-                      )   
+                      )
    )
 
   (:action put-up
    :parameters (?r - robot ?basex - xc ?basey - yc
                 ?gxrel - xrel ?gxabs - xc ?gyrel - yrel ?gyabs - yc
-                ?o - object ?oy - yc)   
+                ?o - object ?oy - yc)
    :precondition (and (parked ?r)
                       (base-pos ?r ?basex ?basey)
                       (gripper-rel ?r ?gxrel ?gyrel)
@@ -394,13 +394,13 @@
                       (object-pos ?o ?gxabs ?oy)
                       (gripper-obstacle ?gxabs ?oy)
                       (gripper-empty ?r)
-                      )   
+                      )
    )
 
   (:action put-down
    :parameters (?r - robot ?basex - xc ?basey - yc
                 ?gxrel - xrel ?gxabs - xc ?gyrel - yrel ?gyabs - yc
-                ?o - object ?oy - yc)   
+                ?o - object ?oy - yc)
    :precondition (and (parked ?r)
                       (base-pos ?r ?basex ?basey)
                       (gripper-rel ?r ?gxrel ?gyrel)
@@ -415,12 +415,12 @@
                       (object-pos ?o ?gxabs ?oy)
                       (gripper-obstacle ?gxabs ?oy)
                       (gripper-empty ?r)
-                      )   
+                      )
    )
 
   (:action put-on-cart
-   :parameters (?r - robot ?x - xc ?y - yc ?gxrel - xrel 
-                ?gyrel - yrel ?o - object ?c - cart ?cx - xc ?cy - yc)
+   :parameters (?r - robot ?x - xc ?y - yc ?gxrel - xrel
+                ?gyrel - yrel ?o - object ?c - cart_t ?cx - xc ?cy - yc)
 
    :precondition (and (parked ?r) (base-pos ?r ?x ?y) (gripper-rel ?r ?gxrel ?gyrel)
                       (sum-x ?x ?gxrel ?cx) (sum-y ?y ?gyrel ?cy) (cart-pos ?c ?cx ?cy)

--- a/tidybot-sat11-strips/p01.pddl
+++ b/tidybot-sat11-strips/p01.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-sat11-strips/p02.pddl
+++ b/tidybot-sat11-strips/p02.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-sat11-strips/p03.pddl
+++ b/tidybot-sat11-strips/p03.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-sat11-strips/p04.pddl
+++ b/tidybot-sat11-strips/p04.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-sat11-strips/p05.pddl
+++ b/tidybot-sat11-strips/p05.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-sat11-strips/p06.pddl
+++ b/tidybot-sat11-strips/p06.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-sat11-strips/p07.pddl
+++ b/tidybot-sat11-strips/p07.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-sat11-strips/p08.pddl
+++ b/tidybot-sat11-strips/p08.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-sat11-strips/p09.pddl
+++ b/tidybot-sat11-strips/p09.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-sat11-strips/p10.pddl
+++ b/tidybot-sat11-strips/p10.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-sat11-strips/p11.pddl
+++ b/tidybot-sat11-strips/p11.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-sat11-strips/p12.pddl
+++ b/tidybot-sat11-strips/p12.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-sat11-strips/p13.pddl
+++ b/tidybot-sat11-strips/p13.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-sat11-strips/p14.pddl
+++ b/tidybot-sat11-strips/p14.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-sat11-strips/p15.pddl
+++ b/tidybot-sat11-strips/p15.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-sat11-strips/p16.pddl
+++ b/tidybot-sat11-strips/p16.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-sat11-strips/p17.pddl
+++ b/tidybot-sat11-strips/p17.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-sat11-strips/p18.pddl
+++ b/tidybot-sat11-strips/p18.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-sat11-strips/p19.pddl
+++ b/tidybot-sat11-strips/p19.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 

--- a/tidybot-sat11-strips/p20.pddl
+++ b/tidybot-sat11-strips/p20.pddl
@@ -4,7 +4,7 @@
   
   (:objects 
    pr2 - robot 
-   cart - cart 
+   cart - cart_t
    object0 - object 
    object1 - object 
    object2 - object 


### PR DESCRIPTION
Hi,

I wonder if you'd be interested in incorporating this small "fix" for tidybot in the benchmarks repo. The PR changes the domain / problem definitions so that there no longer is one PDDL type `cart` and one PDDL object name `cart`. It's not clear to me whether this is allowed or not by the unofficial grammar specs, so feel free to simply reject this PR, but to me it seems quite reasonable not to have different entities with exactly the same name.